### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/IRC/Utils.pm
+++ b/lib/IRC/Utils.pm
@@ -1,6 +1,6 @@
 # Copyright (C) 2011, Kevin Polulak <kpolulak@gmail.com>.
 
-module IRC::Utils:<soh_cah_toa 0.2.0>;
+unit module IRC::Utils:<soh_cah_toa 0.2.0>;
 
 =begin pod
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
