### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,15 +1,17 @@
 {
-    "perl"        : "6.*",
-    "name"        : "IRC::Utils",
-    "version"     : "0.2.0",
-    "description" : "A Perl 6 port of the IRC::Utils module",
-    "provides"    : {
-        "IRC::Utils": "lib/IRC/Utils.pm"
-    },
-    "author"      : "Kevin Polulak",
-    "authority"   : "soh-cah-toa",
-    "depends"     : [],
-    "source-type" : "git",
-    "source-url"  : "git://github.com/perl6-community-modules/p6-irc-utils.git"
+  "name": "IRC::Utils",
+  "source-url": "git://github.com/perl6-community-modules/p6-irc-utils.git",
+  "authority": "soh-cah-toa",
+  "perl": "6.*",
+  "source-type": "git",
+  "author": "Kevin Polulak",
+  "depends": [
+    
+  ],
+  "license": "Artistic-2.0",
+  "provides": {
+    "IRC::Utils": "lib/IRC/Utils.pm"
+  },
+  "version": "0.2.0",
+  "description": "A Perl 6 port of the IRC::Utils module"
 }
-


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license